### PR TITLE
Update nginx.conf

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -5,6 +5,8 @@ events {
   worker_connections  1024;
 }
 
+rtmp_auto_push on;
+
 rtmp {
   server {
     listen 1935;


### PR DESCRIPTION
Set `rtmp_auto_push on;` so that users can use multiple nginx workers.

Since Raspberry Pi 2 which is based on Broadcom BCM2836 SoC,
it's reasonable to use multiple nginx workers.
